### PR TITLE
Patch

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-
+    <queries>
+        <package android:name="org.sufficientlysecure.keychain" />
+    </queries>
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"


### PR DESCRIPTION
Without this option, bindToService fails on newer Android API versions.  Once added, the option to select OpenKeychain as an encryption provider becomes available.