### PR TITLE
Move the queries from the example application into the API

### DIFF
--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <queries>
-        <package android:name="org.sufficientlysecure.keychain" />
-    </queries>
+
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"

--- a/openpgp-api/src/main/AndroidManifest.xml
+++ b/openpgp-api/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest>
-
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <queries>
+        <package android:name="org.sufficientlysecure.keychain" />
+    </queries>
     <application/>
 
 </manifest>


### PR DESCRIPTION
This PR should prevent the need for individual applications to have to add the queries to their own `AndroidManifest.xml`